### PR TITLE
Breaking: parse into a simple ast

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,7 @@
 {
   "env": {
-    "node": true
+    "node": true,
+    "esnext": true
   },
   "rules": {
     "curly": [2, "multi-line"],
@@ -10,6 +11,7 @@
     "strict": [2, "global"],
     "no-underscore-dangle": 0,
     "no-use-before-define": [2, "nofunc"],
-    "no-unused-vars": [2, { "vars": "all", "args": "none" }]
+    "no-unused-vars": [2, { "vars": "all", "args": "none" }],
+    "no-undef": 2
   }
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: node_js
 node_js:
-  - "0.12"
-  - "0.11"
-  - "0.10"
-  - "iojs"
+  - "4"
+  - "5"

--- a/lib/glob.js
+++ b/lib/glob.js
@@ -1,0 +1,28 @@
+'use strict'
+
+function glob(pattern, str) {
+  let patterns = pattern.split(/\s+/)
+
+  for (var i = 0, len = patterns.length; i < len; i++) {
+    let negate = false
+
+    pattern = patterns[i]
+    if (pattern.charAt(0) === '!') {
+      negate = true
+      pattern = pattern.slice(1)
+    }
+    pattern = pattern.replace(/\./g, '\\.')
+      .replace(/\*/g, '.*')
+      .replace(/\?/g, '.?')
+      .replace(/,/g, '|')
+
+    if (negate ^ new RegExp('^(?:' + pattern + ')$').test(str)) {
+      return true
+    }
+  }
+
+  return false
+}
+
+
+module.exports = glob

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ssh-config",
   "description": "SSH config parser and stringifier",
-  "version": "0.2.1",
+  "version": "1.0.0-alpha",
   "author": "dotnil <jakeplus@gmail.com>",
   "repository": {
     "type": "git",
@@ -16,6 +16,9 @@
   "scripts": {
     "test": "mocha test/**/*.js",
     "cover": "istanbul cover _mocha -- test/test.*.js -R spec"
+  },
+  "engine": {
+    "node": ">= 4.0.0"
   },
   "license": "MIT"
 }

--- a/test/test.glob.js
+++ b/test/test.glob.js
@@ -1,7 +1,8 @@
 'use strict'
 
 var expect = require('expect.js')
-var glob = require('..').glob
+
+var glob = require('../lib/glob')
 
 
 describe('glob', function() {


### PR DESCRIPTION
... to better retain white spaces and comments. Hence fixes #8 and #9,
closes #10.

Also changed API:

- Renamed `.query` to `.compute`, to clarify against `.find`.
- The object returned by `.compute` will always have the `IdentityFile` property as an Array. Hence makes multiple `IdentityFile` to be able to coexist.
- `.length` is no longer the sections' length. It is now the length of
  the top level rules, e.g. sections created by Host and Match, and wild
  parameters that doesn't belong to any section.

Drop support of Node.js versions below 4.