### PR TITLE
Fix: handle double quotes in directive values

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ const glob = require('./lib/glob')
 const RE_SPACE = /\s/
 const RE_LINE_BREAK = /\r|\n/
 const RE_SECTION_DIRECTIVE = /^(Host|Match)$/i
+const RE_VALUE_TRIM = /^\s*"?|"?\s*$/g
 
 const DIRECTIVE = 1
 const COMMENT = 2
@@ -109,6 +110,15 @@ class SSHConfig extends Array {
    */
   static stringify(config) {
     let str = ''
+
+    let formatValue = value => {
+      if (RE_SPACE.test(value)) {
+        value = '"' + value + '"'
+      }
+
+      return value
+    }
+
     let format = line => {
       str += line.before
 
@@ -116,7 +126,7 @@ class SSHConfig extends Array {
         str += line.content
       }
       else if (line.type === DIRECTIVE) {
-        str += [line.param, line.separator, line.value].join('')
+        str += [line.param, line.separator, formatValue(line.value)].join('')
       }
 
       str += line.after
@@ -196,7 +206,7 @@ class SSHConfig extends Array {
         chr = next()
       }
 
-      return val.trim()
+      return val.replace(RE_VALUE_TRIM, '')
     }
 
     function comment() {

--- a/index.js
+++ b/index.js
@@ -111,8 +111,8 @@ class SSHConfig extends Array {
   static stringify(config) {
     let str = ''
 
-    let formatValue = value => {
-      if (RE_SPACE.test(value)) {
+    let formatValue = (name, value) => {
+      if (name === 'IdentityFile' && RE_SPACE.test(value)) {
         value = '"' + value + '"'
       }
 
@@ -126,7 +126,7 @@ class SSHConfig extends Array {
         str += line.content
       }
       else if (line.type === DIRECTIVE) {
-        str += [line.param, line.separator, formatValue(line.value)].join('')
+        str += [line.param, line.separator, formatValue(line.param, line.value)].join('')
       }
 
       str += line.after

--- a/test/fixture/config
+++ b/test/fixture/config
@@ -16,4 +16,4 @@ Host *
 Host tahoe?
   User nil
   ForwardAgent true
-  ProxyCommand "ssh -q gateway -W %h:%p"
+  ProxyCommand ssh -q gateway -W %h:%p

--- a/test/fixture/config
+++ b/test/fixture/config
@@ -16,4 +16,4 @@ Host *
 Host tahoe?
   User nil
   ForwardAgent true
-  ProxyCommand ssh -q gateway -W %h:%p
+  ProxyCommand "ssh -q gateway -W %h:%p"

--- a/test/test.ssh-config.js
+++ b/test/test.ssh-config.js
@@ -125,6 +125,20 @@ describe('sshConfig', function() {
   })
 
 
+  it('.parse IdentityFile with spaces', function() {
+    let config = sshConfig.parse(heredoc(function() {/*
+      IdentityFile C:\Users\fname lname\.ssh\id_rsa
+      IdentityFile "C:\Users\fname lname\.ssh\id_rsa"
+    */}))
+
+    expect(config[0].param).to.equal('IdentityFile')
+    expect(config[0].value).to.equal('C:\\Users\\fname lname\\.ssh\\id_rsa')
+
+    expect(config[1].param).to.equal('IdentityFile')
+    expect(config[1].value).to.equal('C:\\Users\\fname lname\\.ssh\\id_rsa')
+  })
+
+
   it('.stringify the parsed object back to string', function() {
     let fixture = readFile('fixture/config')
     let config = sshConfig.parse(fixture)
@@ -149,6 +163,23 @@ describe('sshConfig', function() {
         HostName tahoe4.com
         # Breeze from the hills
         User keanu
+    */}))
+  })
+
+
+  it('.stringify entries with double quotes', function() {
+    let config = sshConfig.parse(heredoc(function() {/*
+      Host example
+        HostName example.com
+        User dan
+        IdentityFile "/path to my/.ssh/id_rsa"
+    */}))
+
+    expect(sshConfig.stringify(config)).to.equal(heredoc(function() {/*
+      Host example
+        HostName example.com
+        User dan
+        IdentityFile "/path to my/.ssh/id_rsa"
     */}))
   })
 

--- a/test/test.ssh-config.js
+++ b/test/test.ssh-config.js
@@ -182,8 +182,7 @@ describe('sshConfig', function() {
       Host example
         HostName example.com
         User dan
-        IdentityFile /path to my/.ssh/id_rsa
-        IdentityFile "/path to my/.ssh/id_rsa2"
+        IdentityFile "/path to my/.ssh/id_rsa"
     */}))
 
     expect(sshConfig.stringify(config)).to.equal(heredoc(function() {/*
@@ -191,7 +190,6 @@ describe('sshConfig', function() {
         HostName example.com
         User dan
         IdentityFile "/path to my/.ssh/id_rsa"
-        IdentityFile "/path to my/.ssh/id_rsa2"
     */}))
   })
 

--- a/test/test.ssh-config.js
+++ b/test/test.ssh-config.js
@@ -167,12 +167,13 @@ describe('sshConfig', function() {
   })
 
 
-  it('.stringify entries with double quotes', function() {
+  it('.stringify IdentityFile entries with double quotes', function() {
     let config = sshConfig.parse(heredoc(function() {/*
       Host example
         HostName example.com
         User dan
-        IdentityFile "/path to my/.ssh/id_rsa"
+        IdentityFile /path to my/.ssh/id_rsa
+        IdentityFile "/path to my/.ssh/id_rsa2"
     */}))
 
     expect(sshConfig.stringify(config)).to.equal(heredoc(function() {/*
@@ -180,6 +181,7 @@ describe('sshConfig', function() {
         HostName example.com
         User dan
         IdentityFile "/path to my/.ssh/id_rsa"
+        IdentityFile "/path to my/.ssh/id_rsa2"
     */}))
   })
 

--- a/test/test.ssh-config.js
+++ b/test/test.ssh-config.js
@@ -139,6 +139,16 @@ describe('sshConfig', function() {
   })
 
 
+  it('.parse Host with double quotes', function() {
+    let config = sshConfig.parse(heredoc(function() {/*
+      Host foo "!*.bar"
+    */}))
+
+    expect(config[0].param).to.equal('Host');
+    expect(config[0].value).to.equal('foo "!*.bar"')
+  })
+
+
   it('.stringify the parsed object back to string', function() {
     let fixture = readFile('fixture/config')
     let config = sshConfig.parse(fixture)


### PR DESCRIPTION
Hi! First of all, thanks for the library. Ionic makes use of it in [our CLI](https://github.com/ionic-team/ionic-cli). Our devs have discovered what we think is a bug:

> If a value in an `SSHConfig` object contains spaces and is stringified,
> the resultant SSH config file is invalid, erroring with something like:
> 
> `/Users/dan/.ssh/config line 5: garbage at end of line`
> 
> This fix ensures values are written with surrounding double quotes, as
> specified in the "Format of SSH client config file" section of
> https://www.ssh.com/ssh/config.

I've included a fix with tests. 