### PR TITLE
Fix indentation when using .append method

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,6 +91,7 @@ class SSHConfig extends Array {
   append(opts) {
     let config = this
     let configWas = this
+    const lastParam = opts[Object.keys(opts)[Object.keys(opts).length - 1]]
 
     for (const param in opts) {
       const line = {
@@ -99,7 +100,7 @@ class SSHConfig extends Array {
         separator: ' ',
         value: opts[param],
         before: '',
-        after: '\n  '
+        after: lastParam === opts[param] ? '\n\n': '\n  '
       }
 
       if (RE_SECTION_DIRECTIVE.test(param)) {

--- a/index.js
+++ b/index.js
@@ -107,7 +107,7 @@ class SSHConfig extends Array {
         config.push(line)
         config = line.config = new SSHConfig()
       } else {
-        line.before = '\t'
+        line.before = '  '
         config.push(line)
       }
     }

--- a/index.js
+++ b/index.js
@@ -91,7 +91,6 @@ class SSHConfig extends Array {
   append(opts) {
     let config = this
     let configWas = this
-    const lastParam = opts[Object.keys(opts)[Object.keys(opts).length - 1]]
 
     for (const param in opts) {
       const line = {
@@ -100,7 +99,7 @@ class SSHConfig extends Array {
         separator: ' ',
         value: opts[param],
         before: '',
-        after: lastParam === opts[param] ? '\n\n': '\n  '
+        after: '\n'
       }
 
       if (RE_SECTION_DIRECTIVE.test(param)) {
@@ -108,9 +107,12 @@ class SSHConfig extends Array {
         config.push(line)
         config = line.config = new SSHConfig()
       } else {
+        line.before = '\t'
         config.push(line)
       }
     }
+
+    config[config.length - 1].after += '\n'
 
     return configWas
   }

--- a/test/test.ssh-config.js
+++ b/test/test.ssh-config.js
@@ -330,14 +330,14 @@ describe('SSHConfig', function() {
       value: 'example2.com',
       config: [{
         type: DIRECTIVE,
-        before: '\t',
+        before: '  ',
         after: '\n',
         param: 'User',
         separator: ' ',
         value: 'pegg'
       },{
         type: DIRECTIVE,
-        before: '\t',
+        before: '  ',
         after: '\n\n',
         param: 'IdentityFile',
         separator: ' ',

--- a/test/test.ssh-config.js
+++ b/test/test.ssh-config.js
@@ -321,5 +321,28 @@ describe('SSHConfig', function() {
     const opts = config.compute('example2.com')
     expect(opts.User).to.eql('pegg')
     expect(opts.IdentityFile).to.eql(['~/.ssh/id_rsa'])
+    expect(config.find({ Host: 'example2.com' })).to.eql({
+      type: DIRECTIVE,
+      before: '',
+      after: '\n',
+      param: 'Host',
+      separator: ' ',
+      value: 'example2.com',
+      config: [{
+        type: DIRECTIVE,
+        before: '\t',
+        after: '\n',
+        param: 'User',
+        separator: ' ',
+        value: 'pegg'
+      },{
+        type: DIRECTIVE,
+        before: '\t',
+        after: '\n\n',
+        param: 'IdentityFile',
+        separator: ' ',
+        value: '~/.ssh/id_rsa'
+      }]
+    })
   })
 })


### PR DESCRIPTION
Hi @dotnil 

One last minor issue with the `.append` method. When using it, the ssh config will look like:
```
Host tahoe
    HostName tahoe.com
    Host walden
    HostName waldenlake.org
```
Instead of:
```
Host tahoe
    HostName tahoe.com

Host walden
  HostName waldenlake.org
```

While it still works that way, adding a new line at the end of each section makes it more readable. 
