### PR TITLE
Fix improper parsing of ProxyCommand with quotation marks

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const glob = require('./src/glob')
 const RE_SPACE = /\s/
 const RE_LINE_BREAK = /\r|\n/
 const RE_SECTION_DIRECTIVE = /^(Host|Match)$/i
-const RE_MULTI_VALUE_DIRECTIVE = /^(GlobalKnownHostsFile|Host|IPQoS|SendEnv|UserKnownHostsFile)$/i
+const RE_MULTI_VALUE_DIRECTIVE = /^(GlobalKnownHostsFile|Host|IPQoS|SendEnv|UserKnownHostsFile|ProxyCommand)$/i
 const RE_QUOTE_DIRECTIVE = /^(?:CertificateFile|IdentityFile|User)$/i
 const RE_SINGLE_LINE_DIRECTIVE = /^(Include|IdentityFile)$/i
 

--- a/test/test.parse.js
+++ b/test/test.parse.js
@@ -139,7 +139,17 @@ describe('parse', function() {
   it('.parse unquoted values that contain double quotes', function() {
     const config = parse('ProxyCommand ssh -W "%h:%p" firewall.example.org')
     assert.equal(config[0].param, 'ProxyCommand')
-    assert.equal(config[0].value, 'ssh -W "%h:%p" firewall.example.org')
+    assert.deepEqual(config[0].value, ['ssh', '-W', '%h:%p', 'firewall.example.org'])
+  })
+
+  // https://github.com/microsoft/vscode-remote-release/issues/5562
+  it('.parse ProxyCommand with multiple args, some quoted', function() {
+    const config = parse(heredoc(function() {/*
+      Host foo
+        ProxyCommand "C:\foo bar\baz.exe" "arg" "arg" "arg"
+    */}))
+    assert.equal(config[0].config[0].param, 'ProxyCommand')
+    assert.deepEqual(config[0].config[0].value, ['C:\\foo bar\\baz.exe', 'arg', 'arg', 'arg'])
   })
 
   it('.parse open ended values', function() {

--- a/test/test.ssh-config.js
+++ b/test/test.ssh-config.js
@@ -36,7 +36,7 @@ describe('SSHConfig', function() {
       IdentityFile: [
         '~/.ssh/id_rsa'
       ],
-      ProxyCommand: 'ssh -q gateway -W %h:%p',
+      ProxyCommand: ['ssh', '-q', 'gateway', '-W', '%h:%p'],
       ServerAliveInterval: '80',
       User: 'nil',
       ForwardAgent: 'true'

--- a/test/test.stringify.js
+++ b/test/test.stringify.js
@@ -132,4 +132,17 @@ describe('stringify', function() {
         IdentityFile "C:\Users\John Doe\.ssh\id_rsa"
     */}))
   })
+
+  // https://github.com/microsoft/vscode-remote-release/issues/5562
+  it('.stringify ProxyCommand with spaces', function() {
+    const config = parse(heredoc(function() {/*
+      Host foo
+        ProxyCommand "C:\foo bar\baz.exe" "arg" "arg" "arg"
+    */}))
+
+    assert.equal(stringify(config), heredoc(function() {/*
+      Host foo
+        ProxyCommand "C:\foo bar\baz.exe" arg arg arg
+    */}))
+  })
 })


### PR DESCRIPTION
Related to https://github.com/microsoft/vscode-remote-release/issues/5562

Hey @cyjake!

ProxyCommand is the field that specifies the commands to run. The appropriate usage is something like this:
```
ProxyCommand ssh -W "%h:%p" firewall.example.org
```

and would result in the properly formatted version of:
```
ProxyCommand ssh -W %h:%p firewall.example.org
```

not this since it won't run properly in the shell:
```
ProxyCommand 'ssh -W "%h:%p" firewall.example.org'
```

But if you have any spaces in the args, the appropriate config would look like this where args with spaces need to be surrounded in quotes:
```
ProxyCommand "C:\foo bar\baz.exe" arg arg arg
```

In the linked issue the ProxyCommand was parsed incorrectly because it was not being parsed as a multiple argument directive. 