### PR TITLE
feat: support Buffer input for parse function

### DIFF
--- a/src/ssh-config.ts
+++ b/src/ssh-config.ts
@@ -1,4 +1,5 @@
 
+import { Buffer } from 'node:buffer'
 import glob from './glob.ts'
 import { spawnSync } from 'node:child_process'
 import os from 'node:os'
@@ -230,7 +231,7 @@ export default class SSHConfig extends Array<Line> {
   /**
    * Parse SSH config text into structured object.
    */
-  public static parse(text: string): SSHConfig {
+  public static parse(text: string | Buffer): SSHConfig {
     return parse(text)
   }
 
@@ -531,14 +532,17 @@ export default class SSHConfig extends Array<Line> {
 /**
  * Parse SSH config text into structured object.
  */
-export function parse(text: string): SSHConfig {
+export function parse(text: string | Buffer): SSHConfig {
+  // Handle Buffer input by converting to string
+  const input: string = typeof text === 'string' ? text : text.toString('utf-8')
+
   let i = 0
   let chr = next()
   let config: SSHConfig = new SSHConfig()
   let configWas = config
 
   function next() {
-    return text[i++]
+    return input[i++]
   }
 
   function space(): Space {

--- a/test/unit/parse.test.ts
+++ b/test/unit/parse.test.ts
@@ -355,4 +355,14 @@ describe('parse', function() {
     assert.equal(config[0].type, LineType.DIRECTIVE)
     assert.equal(config[0].value, 'name#with#hash')
   })
+
+  // https://github.com/cyjake/ssh-config/issues/103
+  it('.parse Buffer input', async function() {
+    const text = await readFixture('config')
+    const buffer = Buffer.from(text, 'utf-8')
+    const configFromBuffer = parse(buffer)
+    const configFromString = parse(text)
+
+    assert.deepEqual(configFromBuffer, configFromString)
+  })
 })


### PR DESCRIPTION
- Add Buffer type import from node:buffer for Deno compatibility
- Update parse() to accept string | Buffer as input
- Add unit test for Buffer input parsing

Fixes #103