### PR TITLE
Add option to skip Match exec evaluation

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -115,6 +115,16 @@ config.compute('example')
 // With ignoreCase - lowercase to match OpenSSH
 config.compute('example', { ignoreCase: true })
 // => { hostname: '1.2.3.4', user: 'admin' }
+
+#### Match Exec
+
+`Match exec` criteria are evaluated by default to match OpenSSH behavior. If
+the config text may be untrusted, pass `{ matchExec: false }` to skip
+`Match exec` sections while still computing `Host` sections and non-exec
+`Match` criteria:
+
+```js
+config.compute('walden', { matchExec: false })
 ```
 
 ### `.find` sections by Host or Match

--- a/src/ssh-config.ts
+++ b/src/ssh-config.ts
@@ -141,6 +141,13 @@ export interface MatchOptions {
 export interface ComputeOptions {
   /** when true, normalizes directive names to lowercase to match OpenSSH behavior */
   ignoreCase?: boolean;
+  /**
+   * Whether to evaluate Match exec criteria.
+   *
+   * Defaults to true for OpenSSH-compatible behavior. Set to false when
+   * computing potentially untrusted config text to avoid shell execution.
+   */
+  matchExec?: boolean;
 }
 
 interface MatchParams {
@@ -153,6 +160,7 @@ interface MatchParams {
 
 interface ComputeContext {
   params: MatchParams;
+  options: Required<ComputeOptions>;
   doFinalPass: boolean;
   inFinalPass: boolean;
 }
@@ -196,6 +204,9 @@ function match(criteria: Match['criteria'], context: ComputeContext): boolean {
         context.doFinalPass = true
         return false
       case 'exec':
+        if (!context.options.matchExec) {
+          return false
+        }
         const command = `function main {
           ${criterion}
         }
@@ -253,17 +264,12 @@ export default class SSHConfig extends Array<Line> {
   /**
    * Query SSH config by host.
    */
-  public compute(host: string): Record<string, string | string[]>;
+  public compute(host: string, options?: ComputeOptions): Record<string, string | string[]>;
 
   /**
    * Query SSH config by host and user.
    */
   public compute(opts: MatchOptions, computeOpts?: ComputeOptions): Record<string, string | string[]>;
-
-  /**
-   * Query SSH config by host with options.
-   */
-  public compute(host: string, computeOpts?: ComputeOptions): Record<string, string | string[]>;
 
   public compute(opts: string | MatchOptions, computeOpts?: ComputeOptions): Record<string, string | string[]> {
     if (typeof opts === 'string') opts = { Host: opts }
@@ -283,6 +289,10 @@ export default class SSHConfig extends Array<Line> {
         OriginalHost: opts.Host,
         User: userInfo.username,
         LocalUser: userInfo.username,
+      },
+      options: {
+        ignoreCase: computeOpts?.ignoreCase === true,
+        matchExec: computeOpts?.matchExec !== false,
       },
       inFinalPass: false,
       doFinalPass: false,

--- a/test/unit/compute.test.ts
+++ b/test/unit/compute.test.ts
@@ -161,6 +161,24 @@ describe('compute', function() {
     assert.equal(result.HostName, 'tahoe.local')
   })
 
+  it('.compute can skip Match exec', async function() {
+    const config = SSHConfig.parse(`
+      Host tahoe1
+        User nil
+
+      Match exec "return 0" host tahoe1
+        HostName tahoe.local
+
+      Match host tahoe1
+        Port 2222
+    `)
+    const result = config.compute('tahoe1', { matchExec: false })
+    assert.ok(result)
+    assert.equal(result.User, 'nil')
+    assert.equal(result.HostName, undefined)
+    assert.equal(result.Port, '2222')
+  })
+
   it('.compute by Match host and user', async function() {
     const config = SSHConfig.parse(`
       Match host tahoe1 user foo


### PR DESCRIPTION
Adds a compute option for consumers that need to avoid shell execution from Match exec while preserving the default OpenSSH-compatible behavior.

Usage:

```js
config.compute(host, { matchExec: false })
```

Fixes #107