### PR TITLE
Embed sources in generated source maps

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "emitDecoratorMetadata": true,
     "esModuleInterop": true,
     "sourceMap": true,
+    "inlineSources": true,
     "skipLibCheck": true,
     "strictNullChecks": true,
     "declaration": true,


### PR DESCRIPTION
Enables inlineSources so published .js.map files include their original TypeScript source content instead of pointing bundlers at missing package files.

Fixes #106