### PR TITLE
chore: use public repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Chen Yangjian (https://www.cyj.me)",
   "repository": {
     "type": "git",
-    "url": "git@github.com:cyjake/ssh-config.git"
+    "url": "git+https://github.com/cyjake/ssh-config.git"
   },
   "files": [
     "dist/**",


### PR DESCRIPTION
## Summary
- replace the SSH/SCP-style repository metadata URL with the public HTTPS GitHub URL
- keep the change limited to package metadata only

## Validation
- `node` package metadata assertion
- `git diff --check`
- `npm pack --dry-run --ignore-scripts --json .`
